### PR TITLE
Simplified CG tweaks

### DIFF
--- a/scripts/LAPD-like_simplified_CG.py
+++ b/scripts/LAPD-like_simplified_CG.py
@@ -4,30 +4,35 @@
 # and Nektar-Driftwave_port_irksome_STFC_v2_working_submit.py (transverse dynamics)
 # this version fixes wrong equation for longitudial velocity cpt
 
-from firedrake import as_vector, BoxMesh, Constant, DirichletBC, div, dot, dx, exp, Function, FunctionSpace, grad, inner, PETSc, SpatialCoordinate, solve, split, sqrt, TestFunction, TestFunctions, TrialFunction, VectorSpaceBasis, VTKFile
+# fmt: off
+from firedrake import as_vector, BoxMesh, Constant, DirichletBC, div, dot, dx,\
+     exp, Function, FunctionSpace, grad, inner, PETSc, SpatialCoordinate,\
+     solve, split, sqrt, TestFunction, TestFunctions, TrialFunction,\
+     VectorSpaceBasis, VTKFile
+# fmt: on
 import math
-from irksome import Dt, GaussLegendre, MeshConstant, TimeStepper
+from irksome import Dt, GaussLegendre, TimeStepper
 import time
 
 meshres = 64
-h=1.0/meshres
+h = 1.0 / meshres
 mesh = BoxMesh(16, meshres, meshres, 2.0, 0.2, 0.2, hexahedral=True)
 
-V1 = FunctionSpace(mesh, "CG", 1) # n
+V1 = FunctionSpace(mesh, "CG", 1)  # n
 V2 = FunctionSpace(mesh, "CG", 1)  # u - velocity x-cpt
-V3 = FunctionSpace(mesh, "CG", 1) # w
-V = V1*V2*V3
-V4 = FunctionSpace(mesh, "CG", 1) # phi
+V3 = FunctionSpace(mesh, "CG", 1)  # w
+V = V1 * V2 * V3
+V4 = FunctionSpace(mesh, "CG", 1)  # phi
 
 # time parameters (4.0 / 100 is the standard for longitudinal-only)
 T = 4.0
 timeres = 200
 t = Constant(0.0)
-dt = Constant(T/timeres)
+dt = Constant(T / timeres)
 
 # parameters for irksome
 butcher_tableau = GaussLegendre(1)
-#butcher_tableau = GaussLegendre(2)  # bit slow on my laptop, makes it take 8 hrs on 8 cores
+# butcher_tableau = GaussLegendre(2)  # bit slow on my laptop, makes it take 8 hrs on 8 cores
 
 # model parameters
 nstar = Constant(1.0)
@@ -43,55 +48,63 @@ v4 = TestFunction(V4)
 phi_s = Function(V4)
 
 # sonic outflow equilibrium init data
-#nuw.sub(0).interpolate((nstar/sqrt(Temp))*(1+sqrt(1-x[0]*x[0])))
-#nuw.sub(1).interpolate((sqrt(Temp)/(x[0]))*(1-sqrt(1-x[0]*x[0])))
+# nuw.sub(0).interpolate((nstar/sqrt(Temp))*(1+sqrt(1-x[0]*x[0])))
+# nuw.sub(1).interpolate((sqrt(Temp)/(x[0]))*(1-sqrt(1-x[0]*x[0])))
 
 # source function, amplitude was simple cranked up until nontrivial behaviour was seen
 nstarFunc = Function(V1)
-nstarFunc.interpolate(nstar*0.0 + 100.0*exp(-((x[1]-0.1)**2+(x[2]-0.1)**2)/(2*width_T**2)))
+nstarFunc.interpolate(nstar*0.0 + 100.0*exp(-((x[1]-0.1)**2+(x[2]-0.1)**2)/(2*width_T**2)))  # fmt: skip
 
-outpath_ICs="LAPD-like_CG_v2_init.pvd"
-PETSc.Sys.Print("Writing ICs to ",outpath_ICs)
+outpath_ICs = "LAPD-like_CG_v2_init.pvd"
+PETSc.Sys.Print("Writing ICs to ", outpath_ICs)
 VTKFile(outpath_ICs).write(nuw.sub(0), nuw.sub(1), nuw.sub(2))
 
 # dev version with longitudinal and transverse dynamics
 # last 3 terms are the artificial viscosity
+# fmt: off
 F = ((Dt(n)*v1)*dx + (n*Dt(u)*v2 + Dt(w)*v3)*dx) \
    + (v1*div(n*as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]))-v1*nstarFunc)*dx \
    + (v3*div(w*as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]))+v3*grad(n*u)[0])*dx \
    + (nstarFunc*u*v2+v2*n*inner(grad(u),as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]))+Temp*grad(n)[0]*v2)*dx \
    + 0.3*(0.5*h*(dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(n)-as_vector([0,0,nstarFunc])))*dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(v1)))*(1/sqrt((grad(phi_s)[1])**2+(grad(phi_s)[2])**2+u**2+0.0001))*dx \
    + 0.3*(0.5*h*(dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(w)))*dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(v3)))*(1/sqrt((grad(phi_s)[1])**2+(grad(phi_s)[2])**2+u**2+0.0001))*dx \
-   + 0.3*(0.5*h*(dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(n*u)))*dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(v2)))*(1/sqrt((grad(phi_s)[1])**2+(grad(phi_s)[2])**2+u**2+0.0001))*dx \
-
+   + 0.3*(0.5*h*(dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(n*u)))*dot(as_vector([u,grad(phi_s)[2],-grad(phi_s)[1]]),grad(v2)))*(1/sqrt((grad(phi_s)[1])**2+(grad(phi_s)[2])**2+u**2+0.0001))*dx
+# fmt: on
 # params taken from Cahn-Hilliard example cited above
-params = {'snes_monitor': None, 'snes_max_it': 100,
-          'snes_linesearch_type': 'l2',
-          'ksp_type': 'preonly',
-          'pc_type': 'lu', 'mat_type': 'aij',
-          'pc_factor_mat_solver_type': 'mumps'}
+params = {
+    "snes_monitor": None,
+    "snes_max_it": 100,
+    "snes_linesearch_type": "l2",
+    "ksp_type": "preonly",
+    "pc_type": "lu",
+    "mat_type": "aij",
+    "pc_factor_mat_solver_type": "mumps",
+}
 
 # Dirichlet BCs are needed for boundary velocity
 
-bc_outflow_1 = DirichletBC(V.sub(1),-1,1)
-bc_outflow_2 = DirichletBC(V.sub(1), 1,2)
+bc_outflow_1 = DirichletBC(V.sub(1), -1, 1)
+bc_outflow_2 = DirichletBC(V.sub(1), 1, 2)
 
-bc_n = DirichletBC(V.sub(0), 0.0, [3,4,5,6])
+bc_n = DirichletBC(V.sub(0), 0.0, [3, 4, 5, 6])
 
-stepper = TimeStepper(F, butcher_tableau, t, dt, nuw, solver_parameters=params, bcs=[bc_outflow_1, bc_outflow_2])
+stepper = TimeStepper(F, butcher_tableau, t, dt, nuw, solver_parameters=params, bcs=[bc_outflow_1, bc_outflow_2])  # fmt: skip
 
 # elliptic solve for potential
-Lphi = inner(grad(phi),grad(v4))*dx
-Rphi = -w*v4*dx
-#phi_s = Function(V4)
-bc1 = DirichletBC(V4, 0, 'on_boundary')
+Lphi = inner(grad(phi), grad(v4)) * dx
+Rphi = -w * v4 * dx
+# phi_s = Function(V4)
+bc1 = DirichletBC(V4, 0, "on_boundary")
 
 # this is intended to be direct solver - but now changed to GMRES
-linparams = {"mat_type": "aij",
-          "snes_type": "ksponly",
-          "ksp_type": "gmres",
-          "pc_type": "lu", 'mat_type': 'aij',
-          'pc_factor_mat_solver_type': 'mumps'}
+linparams = {
+    "mat_type": "aij",
+    "snes_type": "ksponly",
+    "ksp_type": "gmres",
+    "pc_type": "lu",
+    "mat_type": "aij",
+    "pc_factor_mat_solver_type": "mumps",
+}
 
 nullspace = VectorSpaceBasis(constant=True)
 
@@ -108,33 +121,32 @@ PETSc.Sys.Print(f" T_end   = {float(T):.5g}")
 PETSc.Sys.Print(f" meshres = {meshres:d}")
 
 PETSc.Sys.Print("\nTimestep loop:")
-step=0
+step = 0
 while float(t) < float(T):
     it_start = time.time()
     if (float(t) + float(dt)) >= T:
         dt.assign(T - float(t))
         PETSc.Sys.Print(f"  Last dt = {dt}")
-    solve(Lphi==Rphi, phi_s, nullspace=nullspace, solver_parameters=linparams, bcs=bc1)
+    solve(Lphi==Rphi, phi_s, nullspace=nullspace, solver_parameters=linparams, bcs=bc1)  # fmt: skip
 
     nuw.sub(0).rename("density")
     nuw.sub(1).rename("velocity")
     nuw.sub(2).rename("vorticity")
     p = Function(V1)
-    p.interpolate(nuw.sub(0)*nuw.sub(1))
+    p.interpolate(nuw.sub(0) * nuw.sub(1))
     p.rename("momentum density")
     phi_s.rename("potential")
     outfile.write(nuw.sub(0), nuw.sub(1), nuw.sub(2), phi_s, p)
 
-
     stepper.advance()
     t.assign(float(t) + float(dt))
     it_end = time.time()
-    it_wall_time = it_end-it_start
+    it_wall_time = it_end - it_start
     PETSc.Sys.Print(f"  Iter {step+1:d}/{timeres:d} took {it_wall_time:.5g} s")
     PETSc.Sys.Print(f"t = {float(t):.5g}")
     step += 1
 end = time.time()
-wall_time = end-start
+wall_time = end - start
 
 PETSc.Sys.Print("\nDone.")
 PETSc.Sys.Print(f"Total wall time: {wall_time:.5g}")

--- a/scripts/LAPD-like_simplified_CG.py
+++ b/scripts/LAPD-like_simplified_CG.py
@@ -20,8 +20,8 @@ V = V1*V2*V3
 V4 = FunctionSpace(mesh, "CG", 1) # phi
 
 # time parameters (4.0 / 100 is the standard for longitudinal-only)
-T = 8.0
-timeres = 400
+T = 4.0
+timeres = 200
 t = Constant(0.0)
 dt = Constant(T/timeres)
 

--- a/scripts/LAPD-like_simplified_CG.py
+++ b/scripts/LAPD-like_simplified_CG.py
@@ -1,8 +1,8 @@
-# LAPD-like_CG_v2.py
+# LAPD-like_simplified_CG.py
 # Attempt at time-dependent solver of LAPD-like equations, with upwind flux
 # based upon SOL_3D_DG_upwind_tdep_irksome_dev.py (longitudinal dynamics)
 # and Nektar-Driftwave_port_irksome_STFC_v2_working_submit.py (transverse dynamics)
-# this version fixes wrong equation for longitudial velocity cpt
+# this version fixes wrong equation for longitudinal velocity cpt
 
 # fmt: off
 from firedrake import as_vector, BoxMesh, Constant, DirichletBC, div, dot, dx,\
@@ -14,9 +14,23 @@ import math
 from irksome import Dt, GaussLegendre, TimeStepper
 import time
 
-meshres = 64
-h = 1.0 / meshres
-mesh = BoxMesh(16, meshres, meshres, 2.0, 0.2, 0.2, hexahedral=True)
+# ================================ User options ================================
+# mesh
+nx = 16
+ny_nz = 64
+Lx = 2.0
+Ly_Lz = 0.2
+use_hex_mesh = True
+
+# time (4.0 / 100 is the standard for longitudinal-only)
+T = 4.0
+timeres = 200
+
+output_base = "LAPD-like_CG_v2"
+# ==============================================================================
+
+h = 1.0 / ny_nz
+mesh = BoxMesh(nx, ny_nz, ny_nz, Lx, Ly_Lz, Ly_Lz, hexahedral=use_hex_mesh)
 
 V1 = FunctionSpace(mesh, "CG", 1)  # n
 V2 = FunctionSpace(mesh, "CG", 1)  # u - velocity x-cpt
@@ -24,9 +38,6 @@ V3 = FunctionSpace(mesh, "CG", 1)  # w
 V = V1 * V2 * V3
 V4 = FunctionSpace(mesh, "CG", 1)  # phi
 
-# time parameters (4.0 / 100 is the standard for longitudinal-only)
-T = 4.0
-timeres = 200
 t = Constant(0.0)
 dt = Constant(T / timeres)
 
@@ -53,9 +64,9 @@ phi_s = Function(V4)
 
 # source function, amplitude was simple cranked up until nontrivial behaviour was seen
 nstarFunc = Function(V1)
-nstarFunc.interpolate(nstar*0.0 + 100.0*exp(-((x[1]-0.1)**2+(x[2]-0.1)**2)/(2*width_T**2)))  # fmt: skip
+nstarFunc.interpolate(nstar*0.0 + 100.0*exp(-((x[1]-0.1)**2+(x[2]-Ly_Lz/2)**2)/(2*width_T**2)))  # fmt: skip
 
-outpath_ICs = "LAPD-like_CG_v2_init.pvd"
+outpath_ICs = f"{output_base}_init.pvd"
 PETSc.Sys.Print("Writing ICs to ", outpath_ICs)
 VTKFile(outpath_ICs).write(nuw.sub(0), nuw.sub(1), nuw.sub(2))
 
@@ -82,11 +93,10 @@ params = {
 }
 
 # Dirichlet BCs are needed for boundary velocity
-
 bc_outflow_1 = DirichletBC(V.sub(1), -1, 1)
 bc_outflow_2 = DirichletBC(V.sub(1), 1, 2)
 
-bc_n = DirichletBC(V.sub(0), 0.0, [3, 4, 5, 6])
+# bc_n = DirichletBC(V.sub(0), 0.0, [3, 4, 5, 6])
 
 stepper = TimeStepper(F, butcher_tableau, t, dt, nuw, solver_parameters=params, bcs=[bc_outflow_1, bc_outflow_2])  # fmt: skip
 
@@ -110,7 +120,7 @@ nullspace = VectorSpaceBasis(constant=True)
 
 # end of stuff for elliptic solve
 
-outfile = VTKFile("LAPD-like_CG_v2.pvd")
+outfile = VTKFile(f"{output_base}.pvd")
 
 start = time.time()
 
@@ -118,7 +128,12 @@ start = time.time()
 PETSc.Sys.Print(f"Using:")
 PETSc.Sys.Print(f" dt      = {float(dt):.5g}")
 PETSc.Sys.Print(f" T_end   = {float(T):.5g}")
-PETSc.Sys.Print(f" meshres = {meshres:d}")
+PETSc.Sys.Print(f" transverse:")
+PETSc.Sys.Print(f"   size  = {ny_nz:d}")
+PETSc.Sys.Print(f"   res   = {Ly_Lz:.5g}")
+PETSc.Sys.Print(f" parallel:")
+PETSc.Sys.Print(f"   size  = {nx:d}")
+PETSc.Sys.Print(f"   res   = {Lx:.5g}")
 
 PETSc.Sys.Print("\nTimestep loop:")
 step = 0


### PR DESCRIPTION
Use PETSC.print for better MPI output, format with black, collect params at the top of the script.